### PR TITLE
fix: Utilize placeholder of API_GROUP instead of hardcode

### DIFF
--- a/acl-configurator/consul-acl-configurator-operator/controllers/consulacl_controller.go
+++ b/acl-configurator/consul-acl-configurator-operator/controllers/consulacl_controller.go
@@ -40,9 +40,11 @@ import (
 	consulacl "github.com/Netcracker/consul-acl-configurator/consul-acl-configurator-operator/api/v1alpha1"
 )
 
-const (
-	consulAclFinalizer = "qubership.org/consulaclconfigurator-controller"
-	errNotFound        = "ACL not found"
+const errNotFound = "ACL not found"
+
+var (
+    apiGroup           = getEnv("API_GROUP", "qubership.org")
+    consulAclFinalizer = fmt.Sprintf("%s/consulaclconfigurator-controller", apiGroup)
 )
 
 var log = logf.Log.WithName("controller_consulacl")

--- a/acl-configurator/consul-acl-configurator-operator/controllers/consulacl_controller.go
+++ b/acl-configurator/consul-acl-configurator-operator/controllers/consulacl_controller.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"

--- a/acl-configurator/consul-acl-configurator-operator/controllers/consulacl_controller.go
+++ b/acl-configurator/consul-acl-configurator-operator/controllers/consulacl_controller.go
@@ -43,8 +43,8 @@ import (
 const errNotFound = "ACL not found"
 
 var (
-    apiGroup           = getEnv("API_GROUP", "qubership.org")
-    consulAclFinalizer = fmt.Sprintf("%s/consulaclconfigurator-controller", apiGroup)
+    GroupVersion = schema.GroupVersion{Group: getEnv("API_GROUP", "qubership.org"), Version: "v1alpha1"}
+    consulAclFinalizer = GroupVersion.Group + "/consulaclconfigurator-controller"
 )
 
 var log = logf.Log.WithName("controller_consulacl")

--- a/acl-configurator/consul-acl-configurator-operator/controllers/consulacl_controller.go
+++ b/acl-configurator/consul-acl-configurator-operator/controllers/consulacl_controller.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -43,10 +42,7 @@ import (
 
 const errNotFound = "ACL not found"
 
-var (
-    GroupVersion = schema.GroupVersion{Group: getEnv("API_GROUP", "qubership.org"), Version: "v1alpha1"}
-    consulAclFinalizer = GroupVersion.Group + "/consulaclconfigurator-controller"
-)
+var consulAclFinalizer = consulacl.GroupVersion.Group + "/consulaclconfigurator-controller"
 
 var log = logf.Log.WithName("controller_consulacl")
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Initially operator was installed with finalizer nc.com

It  has now been upgraded to opensource version with finalizer qs.org: 
https://github.com/Netcracker/qubership-consul/blob/main/acl-configurator/consul-acl-configurator-operator/controllers/consulacl_controller.go#L44
Hence, it cannot find the required finalizer and delete the same.

## Related Tickets & Documents

- Related Issue #PSUPCLCAP-1660
- Closes #PSUPCLCAP-1660

## QA Instructions, Screenshots, Recordings

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
