### PR TITLE
fix: Replaced deprecated return keywords in tests

### DIFF
--- a/integration-tests/robot/tests/consul/alerts/alerts.robot
+++ b/integration-tests/robot/tests/consul/alerts/alerts.robot
@@ -90,4 +90,3 @@ Consul Does Not Exist Alert
 #    Wait Until Keyword Succeeds  ${ALERT_RETRY_TIME}  ${ALERT_RETRY_INTERVAL}
 #    ...  Check That Prometheus Alert Is Inactive  ${CONSUL_IS_DOWN_ALERT_NAME}
 #    [Teardown]  Check Alerts Are Inactive
-

--- a/integration-tests/robot/tests/consul/alerts/alerts.robot
+++ b/integration-tests/robot/tests/consul/alerts/alerts.robot
@@ -25,7 +25,7 @@ Check That Prometheus Alert Is Inactive
 Get Leader IP
     ${leader}=  Get Leader
     ${resp} =  Delete Port  ${leader}
-    [Return]  ${resp}
+    RETURN  ${resp}
 
 Check Servers Readiness
     ${replicas}=  Get Stateful Set Replicas Count  ${CONSUL_HOST}  ${CONSUL_NAMESPACE}

--- a/integration-tests/robot/tests/consul/alerts/alerts.robot
+++ b/integration-tests/robot/tests/consul/alerts/alerts.robot
@@ -90,3 +90,4 @@ Consul Does Not Exist Alert
 #    Wait Until Keyword Succeeds  ${ALERT_RETRY_TIME}  ${ALERT_RETRY_INTERVAL}
 #    ...  Check That Prometheus Alert Is Inactive  ${CONSUL_IS_DOWN_ALERT_NAME}
 #    [Teardown]  Check Alerts Are Inactive
+

--- a/integration-tests/robot/tests/consul/backup/backup.robot
+++ b/integration-tests/robot/tests/consul/backup/backup.robot
@@ -33,7 +33,7 @@ Create Unique Key And Value
 
 Convert Json ${json} To Type
     ${json_dictionary}  Evaluate  json.loads('''${json}''')  json
-    [Return]  ${json_dictionary}
+    RETURN  ${json_dictionary}
 
 Create Test Data
     Add Test Data To Consul  ${test_key}  ${test_value}
@@ -45,7 +45,7 @@ Full Backup
     ${backup_id}=  Set Variable  ${response.content}
     Wait Until Keyword Succeeds  ${BACKUP_TIMEOUT}  ${BACKUP_TIME_INTERVAL}
     ...  Check Backup Status  ${backup_id}  ${False}
-    [Return]  ${backup_id}
+    RETURN  ${backup_id}
 
 Check Backup Status
     [Arguments]  ${backup_id}  ${is_granular}
@@ -80,7 +80,7 @@ Granular Backup
     ${backup_id}=  Set Variable  ${response.content}
     Wait Until Keyword Succeeds  ${BACKUP_TIMEOUT}  ${BACKUP_TIME_INTERVAL}
     ...  Check Backup Status  ${backup_id}  ${True}
-    [Return]  ${backup_id}
+    RETURN  ${backup_id}
 
 Delete Backup From Backup Daemon
     [Arguments]  ${backup_id}

--- a/integration-tests/robot/tests/consul/backup/backup_s3.robot
+++ b/integration-tests/robot/tests/consul/backup/backup_s3.robot
@@ -47,7 +47,7 @@ Full Backup
     ${backup_id}=  Set Variable  ${response.content}
     Wait Until Keyword Succeeds  ${BACKUP_TIMEOUT}  ${BACKUP_TIME_INTERVAL}
     ...  Check Backup Status  ${backup_id}  ${False}
-    [Return]  ${response.text}
+    RETURN  ${response.text}
 
 Check Backup Status
     [Arguments]  ${backup_id}  ${is_granular}
@@ -82,7 +82,7 @@ Granular Backup
     ${backup_id}=  Set Variable  ${response.content}
     Wait Until Keyword Succeeds  ${BACKUP_TIMEOUT}  ${BACKUP_TIME_INTERVAL}
     ...  Check Backup Status  ${backup_id}  ${True}
-    [Return]  ${response.text}
+    RETURN  ${response.text}
 
 Delete Backup From Backup Daemon
     [Arguments]  ${backup_id}

--- a/integration-tests/robot/tests/consul/ha/consul_ha.robot
+++ b/integration-tests/robot/tests/consul/ha/consul_ha.robot
@@ -24,12 +24,12 @@ Check CRUD Operations
 
 Get Consul Leader
     ${response} =  Get Leader
-    [Return]  ${response}
+    RETURN  ${response}
 
 Get IP For Consul Leader
     [Arguments]  ${leader}
     ${resp} =  Delete Port  ${leader}
-    [Return]  ${resp}
+    RETURN  ${resp}
 
 Delete Consul Leader Pod
     [Arguments]  ${leader_ip}
@@ -51,7 +51,7 @@ Leader Should Be Presented
 Get Leader Pod Name By IP
     [Arguments]  ${pod_ip}
     ${resp} =  Look Up Pod Name By Host IP  ${pod_ip}  ${CONSUL_NAMESPACE}
-    [Return]  ${resp}
+    RETURN  ${resp}
 
 *** Test Cases ***
 Test Value With Exceeding Limit Size


### PR DESCRIPTION
Got rid of messages about deprecated keywords in log of integration tests pod