### PR TITLE
fix: enhance restore functionality to check for datacenter snapshots

### DIFF
--- a/backup-daemon/scripts/restore.py
+++ b/backup-daemon/scripts/restore.py
@@ -76,7 +76,13 @@ class Restore:
 
         if not datacenters:
             logging.debug("Datacenters are not specified, full restore for each datacenter will be performed")
-            datacenters = [f.name for f in os.scandir(folder) if f.is_dir()]
+            datacenters = [
+                f.name for f in os.scandir(folder)
+                if f.is_dir() and os.path.isfile(f'{folder}/{f.name}/snapshot.gz')
+            ]
+            if not datacenters:
+                logging.error(f'No datacenter snapshots found in backup folder: {folder}')
+                sys.exit(1)
 
         logging.info(f'Perform restore of snapshot for datacenters {datacenters}')
         for datacenter in datacenters:

--- a/docs/public/installation.md
+++ b/docs/public/installation.md
@@ -369,7 +369,7 @@ enabled PSP admission control you need to prepare Consul service **before** Kube
 1. Upgrade Consul to `0.2.0+` version with enabled `privileged` PSS for namespace.
    Refer to [Deployment to Kubernetes 1.25](#kubernetes-125) guide.
 2. Enable PSS for Kubernetes `rbac.admission: pss`.
-   [KubeMarine:RBAC Admission](https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#configuring-default-profiles)
+   [KubeMarine:RBAC Admission](https://github.com/Netcracker/KubeMarine/blob/main/docs/public/Installation.md#configuring-default-profiles)
   .
 3. Upgrade Consul with disabled PSP `global.enablePodSecurityPolicies: false`.
 4. Upgrade Kubernetes to 1.25.


### PR DESCRIPTION
- Updated the restore method to filter datacenters based on the presence of snapshot files.
- Added error logging and exit if no snapshots are found in the specified backup folder.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

TDB

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
