### PR TITLE
feat: add wait_for_acl_init_job function to monitor ACL initializatio…

### DIFF
--- a/charts/helm/consul-service/templates/integration_tests/role.yaml
+++ b/charts/helm/consul-service/templates/integration_tests/role.yaml
@@ -17,6 +17,7 @@ rules:
       - apps
     resources:
       - statefulsets
+      - jobs
     verbs:
       - get
       - delete

--- a/integration-tests/docker/consul_pods_checker.py
+++ b/integration-tests/docker/consul_pods_checker.py
@@ -16,19 +16,57 @@ import os
 import sys
 import time
 
+import kubernetes.client
+from kubernetes.client.rest import ApiException
+
 sys.path.append('./tests/shared/lib')
 from PlatformLibrary import PlatformLibrary
 
 environ = os.environ
 namespace = environ.get("CONSUL_NAMESPACE")
 service = environ.get("CONSUL_HOST")
-timeout = 500
+timeout = 5000
+
+
+def wait_for_acl_init_job(namespace, service, timeout):
+    job_name = f"{service}-server-acl-init"
+    batch_v1 = kubernetes.client.BatchV1Api()
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            job = batch_v1.read_namespaced_job(job_name, namespace)
+        except ApiException as e:
+            if e.status == 404:
+                # ACL init job does not exist; ACLs likely disabled, skip wait
+                return
+            time.sleep(10)
+            continue
+        except Exception:
+            time.sleep(10)
+            continue
+
+        if job.status.succeeded and job.status.succeeded >= 1:
+            return
+
+        conditions = job.status.conditions or []
+        if any(c.type == "Failed" and c.status == "True" for c in conditions):
+            print(f"ACL init job {job_name} failed", flush=True)
+            sys.exit(1)
+
+        time.sleep(10)
+
+    print(f"Timed out waiting for ACL init job {job_name}", flush=True)
+    sys.exit(1)
+
 
 if __name__ == '__main__':
     try:
         k8s_library = PlatformLibrary()
     except:
         exit(1)
+
+
+
     timeout_start = time.time()
     while time.time() < timeout_start + timeout:
         try:
@@ -45,4 +83,6 @@ if __name__ == '__main__':
             time.sleep(60)
             exit(0)
         time.sleep(10)
+
+    wait_for_acl_init_job(namespace, service, timeout)
     exit(1)

--- a/integration-tests/docker/consul_pods_checker.py
+++ b/integration-tests/docker/consul_pods_checker.py
@@ -40,9 +40,14 @@ def wait_for_acl_init_job(namespace, service, timeout):
                 print("No job acl init")
                 # ACL init job does not exist; ACLs likely disabled, skip wait
                 return True
+
+            if e.status == 401:
+                print("Unauthorized access to ACL init job")
+                return False
             time.sleep(10)
             continue
-        except Exception:
+        except Exception as ex:
+            print(ex, flush=True)
             time.sleep(10)
             continue
 

--- a/integration-tests/docker/consul_pods_checker.py
+++ b/integration-tests/docker/consul_pods_checker.py
@@ -25,7 +25,7 @@ from PlatformLibrary import PlatformLibrary
 environ = os.environ
 namespace = environ.get("CONSUL_NAMESPACE")
 service = environ.get("CONSUL_HOST")
-timeout = 5000
+timeout = 500
 
 
 def wait_for_acl_init_job(namespace, service, timeout):
@@ -37,35 +37,33 @@ def wait_for_acl_init_job(namespace, service, timeout):
             job = batch_v1.read_namespaced_job(job_name, namespace)
         except ApiException as e:
             if e.status == 404:
+                print("No job acl init")
                 # ACL init job does not exist; ACLs likely disabled, skip wait
-                return
+                return True
             time.sleep(10)
             continue
         except Exception:
             time.sleep(10)
             continue
 
-        if job.status.succeeded and job.status.succeeded >= 1:
-            return
+        if job.status.succeeded and job.status.succeeded > 0:
+            return True
 
         conditions = job.status.conditions or []
         if any(c.type == "Failed" and c.status == "True" for c in conditions):
             print(f"ACL init job {job_name} failed", flush=True)
-            sys.exit(1)
+            return False
 
         time.sleep(10)
 
     print(f"Timed out waiting for ACL init job {job_name}", flush=True)
-    sys.exit(1)
-
+    return False
 
 if __name__ == '__main__':
     try:
         k8s_library = PlatformLibrary()
     except:
         exit(1)
-
-
 
     timeout_start = time.time()
     while time.time() < timeout_start + timeout:
@@ -79,10 +77,10 @@ if __name__ == '__main__':
         except:
             time.sleep(10)
             continue
+
         if desired_pods == ready_pods:
             time.sleep(60)
-            exit(0)
-        time.sleep(10)
-
-    wait_for_acl_init_job(namespace, service, timeout)
-    exit(1)
+            if not wait_for_acl_init_job(namespace, service, timeout):
+                sys.exit(1)
+            break
+    sys.exit(0)


### PR DESCRIPTION
…n job status

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This pull request enhances the `consul_pods_checker.py` integration test by adding a check to ensure the Consul ACL initialization job completes before proceeding. It introduces a new function to poll the Kubernetes job status, handles error cases, and increases the default timeout to accommodate the additional wait.

**Kubernetes ACL Initialization Job Handling:**

* Added the `wait_for_acl_init_job` function to poll the Kubernetes job named `{service}-server-acl-init` in the specified namespace, waiting until it succeeds or fails, and exiting with an error if the job fails or times out.
* Integrated the `wait_for_acl_init_job` call into the main execution flow, ensuring the script waits for ACL initialization before exiting with an error.


<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
